### PR TITLE
[Bug] Can't run the bot

### DIFF
--- a/SETTINGS/config.js
+++ b/SETTINGS/config.js
@@ -35,7 +35,7 @@ module.exports = {
             "Shadow Case Key",
             "Operation Wildfire Case Key",
             "Falchion Case Key",
-			"Spectrum Case Key",
+	    "Spectrum Case Key",
             "Operation Breakout Case Key",
             "Chroma 3 Case Key",
             "CS:GO Case Key",
@@ -43,7 +43,7 @@ module.exports = {
             "Gamma Case Key",
             "Gamma 2 Case Key",
             "Glove Case Key",
-			"Spectrum Case Key"
+	    "Spectrum Case Key"
         ] // These are all keys ^ //Mann Co. Supply Crate Key//
 }
 


### PR DESCRIPTION
When I try to install it gives me this: "npm WARN card-bot-timgfx@1.0.0 No repository field."
And when I try to run it gives me this: 
      "Mann Co. Supply Crate Key"
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^

SyntaxError: Unexpected string
    at new Script (vm.js:79:7)
    at createScript (vm.js:251:10)
    at Object.runInThisContext (vm.js:303:10)
    at Module._compile (internal/modules/cjs/loader.js:657:28)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)

And if I remove the Mann Co. Supply Crate Key, It gives me another error.
